### PR TITLE
Fix - Don't rely on [UIColor clearColor]; being set.

### DIFF
--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -46,7 +46,7 @@
     // Create sub views
     self.backgroundImageView = [[UIImageView alloc] initWithFrame:self.bounds];
     self.backgroundImageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    self.backgroundImageView.opaque = YES;
+    self.backgroundImageView.opaque = self.opaque; // Match self
     self.backgroundImageView.clipsToBounds = YES;
     [self addSubview:self.backgroundImageView];
 
@@ -128,9 +128,13 @@
 
     CGFloat dimensionSize = (cornerRadius * 2.0f) + 2.0f;
     CGSize size = (CGSize){dimensionSize, dimensionSize};
-
+    CGFloat r = 0, g = 0, b = 0, a = 0;
     UIGraphicsImageRendererFormat *format = [[UIGraphicsImageRendererFormat alloc] init];
-    format.opaque = !([backgroundColor isEqual:[UIColor clearColor]]);
+
+    // If the background color's _alpha_ is anything other than 1.0, it's not opaque ;)
+    [backgroundColor getRed: &r green: &g blue: &b alpha: &a];
+
+    format.opaque = a == 1.0;
 
     UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size format:format];
     UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext *rendererContext) {


### PR DESCRIPTION
## Overview

There was a dependency on `[UIColor clearColor];` being set as the background color for the `format.opaque` flag. 

I changed this to rely on the alpha channel of the background color instead, to make it more stringent. Opaque was being set to `TRUE` even if the color was set with `withAlphaComponent()`, which is not desired 😉 