### PR TITLE
Trigger actions for `UIControlEventPrimaryActionTriggered` upon touch up inside

### DIFF
--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -257,6 +257,8 @@ static inline BOOL TO_ROUNDED_BUTTON_FLOATS_MATCH(CGFloat firstValue, CGFloat se
     [self setBackgroundColorTappedAnimated:YES];
     [self setButtonScaledTappedAnimated:YES];
 
+    [self sendActionsForControlEvents:UIControlEventPrimaryActionTriggered];
+
     if (self.tappedHandler) { self.tappedHandler(); }
 }
 


### PR DESCRIPTION
Recently, I've came accross the (not so) new `UIControl.Event.primaryActionTriggered` available since iOS 9.

Although the [documentation I could find](https://developer.apple.com/documentation/uikit/uicontrol/event/1618222-primaryactiontriggered) doesn't describe enough about it, [this book](https://books.google.com/books?id=Hgl5DQAAQBAJ&pg=PA660&lpg=PA660&dq=ios+primaryactiontriggered&source=bl&ots=Fm-JrcexKq&sig=ACfU3U309N3tI0Yrmeh5MKSFDJQJpYUKrQ&hl=en&sa=X&redir_esc=y#v=onepage&q=ios%20primaryactiontriggered&f=false) says the following:

> Starting in iOS 9, a control also has a primary control event, a `UIControlEvent` called `.primaryActionTriggered`. The primary control event is Value Changed for all controls except for `UIButton`, where it is Touch Up Inside, and `UITextField`, where it is Did End On Exit.

I believe that `TORoundedButton` should behave like a `UIButton`, and this PR adds this subtle change. It hooks up on the `.touchUpInside` action to fire the actions registered on `.primaryActionTriggered`. Although I couldn't find a way for a `UIControl` subclass to override/change the primary action, this solution adds this capability to `TORoundedButton`.