### PR TITLE
Set titleLabel's backgroundColor on tintColorDidChange

### DIFF
--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -222,6 +222,7 @@ static inline BOOL TO_ROUNDED_BUTTON_FLOATS_MATCH(CGFloat firstValue, CGFloat se
 - (void)tintColorDidChange
 {
     [super tintColorDidChange];
+    self.titleLabel.backgroundColor = self.isTapped ? [UIColor clearColor] : self.tintColor;
     self.isDirty = YES;
     [self setNeedsLayout];
 }
@@ -409,8 +410,8 @@ static inline BOOL TO_ROUNDED_BUTTON_FLOATS_MATCH(CGFloat firstValue, CGFloat se
     // Animate the alpha value of the label
     void (^animationBlock)(void) = ^{
         self.containerView.transform = CGAffineTransformScale(CGAffineTransformIdentity,
-                                                scale,
-                                                scale);
+                                                              scale,
+                                                              scale);
     };
 
     // If we're not animating, just call the blocks manually


### PR DESCRIPTION
When initializing a `TORoundedButton` in the following way:

```swift
let button = RoundedButton(text: "I agree")
button.tintColor = UIColor.appPurple
button.textColor = .white
button.backgroundColor = .white
button.cornerRadius = 4
```

This is the result:

![RoundedButton](https://user-images.githubusercontent.com/1164565/57652648-b3b6d400-75d8-11e9-8bb2-c18246e18fe3.png)

Tapping on the button makes this glitch go away, because `self.titleLabel.backgroundColor = self.isTapped ? [UIColor clearColor] : self.tintColor;` is called.

This PR sets the `titleLabel`'s `backgroundColor` on `layoutSubviews` to avoid this bug.