### PR TITLE
Set alpha when disabling button

### DIFF
--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -521,6 +521,13 @@ static inline BOOL TO_ROUNDED_BUTTON_FLOATS_MATCH(CGFloat firstValue, CGFloat se
     [self setNeedsLayout];
 }
 
+- (void)setEnabled:(BOOL)enabled
+{
+    [super setEnabled:enabled];
+
+    self.alpha = enabled ? 1 : 0.4;
+}
+
 #pragma mark - Graphics Handling -
 + (BOOL)isOpaqueColor:(UIColor *)color
 {


### PR DESCRIPTION
I noticed that calling the `roundedButton.isEnabled = false` doesn't dim it - which is the case in other `UIControl`s.

I noticed that in all setters `_isDirty = YES; [self setNeedsLayout];` are called, and thought about using the same pattern; however, there is no need to layout all the subviews again, so I thought setting alpha directly a more reasonable solution.