### PR TITLE
When disabling, set containerView alpha (and not button's alpha itself)

### DIFF
--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -526,7 +526,7 @@ static inline BOOL TO_ROUNDED_BUTTON_FLOATS_MATCH(CGFloat firstValue, CGFloat se
 {
     [super setEnabled:enabled];
 
-    self.alpha = enabled ? 1 : 0.4;
+    self.containerView.alpha = enabled ? 1 : 0.4;
 }
 
 #pragma mark - Graphics Handling -


### PR DESCRIPTION
This one is actually a better implementation of #15 - It makes more sense to set the `containerView`'s alpha instead of the whole view's alpha.

What do you think, @TimOliver ?