### PR TITLE
Subtitle:  Trivial code change to allow the button title to be multiple lines of text. 

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,4 @@
+To crate a pull request:
+
+https://opensource.com/article/19/7/create-pull-request-github
+

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,0 @@
-To crate a pull request:
-
-https://opensource.com/article/19/7/create-pull-request-github
-

--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -128,6 +128,7 @@ static inline BOOL TO_ROUNDED_BUTTON_FLOATS_MATCH(CGFloat firstValue, CGFloat se
     self.titleLabel.adjustsFontForContentSizeCategory = YES;
     self.titleLabel.backgroundColor = self.tintColor;
     self.titleLabel.text = @"Button";
+    self.titleLabel.numberOfLines = 0;
     [self.containerView addSubview:self.titleLabel];
 
     // Create action events for all possible interactions with this control


### PR DESCRIPTION
Trivial code change allows me to set the button title to a string that contains two lines of text. Example:

let button = RoundedButton()
button.attributedText = NSAttributedString(string: "Line 1\nLine2)

See [issue #39 ](https://github.com/TimOliver/TORoundedButton/issues/39)