### PR TITLE
Added a delegate property to receive button tap events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ x.y.z Release Notes (yyyy-MM-dd)
 
 ### Added
 
+* A `delegate` property to receive tap events for the button where delegates are preferred over blocks.
 * An `isTranslucent` property (and a `blurStyle` property) that replaces the background of buttons from a solid color to a blurred background.
 * A `contentView` property to enable adding custom view content to buttons.
 * `sizeToFit` and `sizeThatFits:` methods to allow automatic sizing of buttons around their content.

--- a/TORoundedButton/TORoundedButton.h
+++ b/TORoundedButton/TORoundedButton.h
@@ -24,8 +24,21 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class TORoundedButton;
+
+@protocol TORoundedButtonDelegate <NSObject>
+
+/// Called when the user taps on the associated button.
+/// - Parameter button: The button object that was tapped.
+- (void)roundedButtonDidTap:(TORoundedButton *)button;
+
+@end
+
 NS_SWIFT_NAME(RoundedButton)
 IB_DESIGNABLE @interface TORoundedButton : UIControl
+
+/// A delegate object that can receive tap events from this button.
+@property (nonatomic, weak) id<TORoundedButtonDelegate> delegate;
 
 /// The radius of the corners of this button (Default is 12.0f).
 @property (nonatomic, assign) IBInspectable CGFloat cornerRadius;

--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -282,8 +282,9 @@ static inline BOOL TO_ROUNDED_BUTTON_FLOATS_MATCH(CGFloat firstValue, CGFloat se
     // Send the semantic button action for apps relying on this action
     [self sendActionsForControlEvents:UIControlEventPrimaryActionTriggered];
 
-    // Trigger the block if it has been set
+    // Broadcast the tap event to all subscribed objects.
     if (self.tappedHandler) { self.tappedHandler(); }
+    [_delegate roundedButtonDidTap:self];
 }
 
 - (void)_didDragOutside {


### PR DESCRIPTION
Blocks can be kind of messy when referencing `self`, leading to potential retain cycles.

This PR adds a `delegate` property that can be used in place (or even alongside) the block handler