### PR TITLE
Gated out the iOS 26 specific APIs

### DIFF
--- a/TORoundedButton/TORoundedButton.h
+++ b/TORoundedButton/TORoundedButton.h
@@ -25,7 +25,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class TORoundedButton;
-@class UICornerConfiguration;
 
 NS_SWIFT_NAME(RoundedButtonDelegate)
 @protocol TORoundedButtonDelegate <NSObject>
@@ -42,9 +41,11 @@ IB_DESIGNABLE @interface TORoundedButton : UIControl
 /// A delegate object that can receive tap events from this button.
 @property (nonatomic, weak) id<TORoundedButtonDelegate> delegate;
 
+#ifdef __IPHONE_26_0
 /// The corner-rounding behaviour of the button's boundaries.
 /// On iOS 26 and above, this is the `.capsule` preset by default.
 @property (nonatomic, strong, nullable) UICornerConfiguration *cornerConfiguration API_AVAILABLE(ios(26.0));
+#endif
 
 /// The radius of the corners of this button.
 /// (Default is 12.0f on iOS 18 and below. For iOS 26.0, changing this property will update `cornerConfiguration`.)

--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -134,11 +134,15 @@ static inline BOOL TO_ROUNDED_BUTTON_FLOATS_MATCH(CGFloat firstValue, CGFloat se
     [self addTarget:self action:@selector(_didDragInside) forControlEvents:UIControlEventTouchDragEnter];
 
     // Set the corner radius depending on app version
+#ifdef __IPHONE_26_0
     if (@available(iOS 26.0, *)) {
         self.cornerConfiguration = [UICornerConfiguration capsuleConfiguration];
     } else {
         _cornerRadius = (_cornerRadius > FLT_EPSILON) ?: 12.0f;
     }
+#else
+    _cornerRadius = (_cornerRadius > FLT_EPSILON) ?: 12.0f;
+#endif
 }
 
 - (void)_makeTitleLabelIfNeeded TOROUNDEDBUTTON_OBJC_DIRECT {
@@ -518,15 +522,20 @@ static inline BOOL TO_ROUNDED_BUTTON_FLOATS_MATCH(CGFloat firstValue, CGFloat se
 
     _cornerRadius = cornerRadius;
 
+#ifdef __IPHONE_26_0
     if (@available(iOS 26.0, *)) {
         UICornerRadius *const radius = [UICornerRadius fixedRadius:_cornerRadius];
         _backgroundView.cornerConfiguration = [UICornerConfiguration configurationWithUniformRadius:radius];
     } else {
         _backgroundView.layer.cornerRadius = _cornerRadius;
     }
+#else
+    _backgroundView.layer.cornerRadius = _cornerRadius;
+#endif
     [self setNeedsLayout];
 }
 
+#ifdef __IPHONE_26_0
 - (void)setCornerConfiguration:(UICornerConfiguration *)cornerConfiguration {
     _backgroundView.cornerConfiguration = cornerConfiguration;
 }
@@ -534,6 +543,7 @@ static inline BOOL TO_ROUNDED_BUTTON_FLOATS_MATCH(CGFloat firstValue, CGFloat se
 - (UICornerConfiguration *)cornerConfiguration {
     return _backgroundView.cornerConfiguration;
 }
+#endif
 
 - (void)setIsTranslucent:(BOOL)isTranslucent {
     if (_isTranslucent == isTranslucent) {

--- a/TORoundedButtonExampleTests/TORoundedButtonExampleTests.m
+++ b/TORoundedButtonExampleTests/TORoundedButtonExampleTests.m
@@ -26,11 +26,15 @@
     XCTAssertEqual(button.tappedTintColorBrightnessOffset, -0.15f);
     XCTAssertEqual(button.tappedButtonScale, 0.97f);
 
+#ifdef __IPHONE_26_0
     if (@available(iOS 26.0, *)) {
         XCTAssertNotNil(button.cornerConfiguration);
     } else {
         XCTAssertEqual(button.cornerRadius, 12.0f);
     }
+#else
+    XCTAssertEqual(button.cornerRadius, 12.0f);
+#endif
 }
 
 - (void)testButtonInteraction


### PR DESCRIPTION
Okay so adding Liquid Glass support would require so much internal change (the content view needs to be inside the background view for the interactive effect to work properly. But we *don't* want that when using the regular rounding style) that I think it's better to just use an official `UIButton` for those cases.

This PR aims to fix the build on iOS 18 by gating all of the iOS 26 specific code