### PR TITLE
Add a Liquid Glass variant for iOS 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
         uses: futureware-tech/simulator-action@v2
         with:
           model: 'iPhone 16e'
-          os_version: '=18.6'
+          os_version: '=26.2'
 
       - name: Run unit tests
         run: |
           xcodebuild \
             -project TORoundedButtonExample.xcodeproj \
             -scheme TORoundedButtonTests \
-            -destination 'platform=iOS Simulator,name=iPhone 16e,OS=18.6' \
+            -destination 'platform=iOS Simulator,name=iPhone 16e,OS=26.2' \
             clean test

--- a/TORoundedButton/TORoundedButton.h
+++ b/TORoundedButton/TORoundedButton.h
@@ -26,6 +26,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class TORoundedButton;
 
+/// The types of static/dynamic visual styles that can be applied to the background.
+typedef NS_ENUM(NSInteger, TORoundedButtonBackgroundStyle) {
+    TORoundedButtonBackgroundStyleSolid,
+    TORoundedButtonBackgroundStyleBlur,
+    TORoundedButtonBackgroundStyleGlass
+};
+
 NS_SWIFT_NAME(RoundedButtonDelegate)
 @protocol TORoundedButtonDelegate <NSObject>
 
@@ -65,11 +72,14 @@ IB_DESIGNABLE @interface TORoundedButton : UIControl
 /// (Default value is 15 points inset from each edge).
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 
-/// Replaces the solid color background with a blur view. (Default is NO)
-@property (nonatomic, assign) BOOL isTranslucent;
+/// The style, whether static or dynamic of the button's background view.
+@property (nonatomic, assign) TORoundedButtonBackgroundStyle backgroundStyle;
 
-/// When `isTranslucent` is `YES`, the amount of blur the background view has.
+/// When `backgroundStyle` is set to `.blur`, the specific blur style to apply.
 @property (nonatomic, assign) UIBlurEffectStyle blurStyle;
+
+/// When `backgroundStyle` is set to `.blur`, the specific blur style to apply.
+@property (nonatomic, assign) UIGlassEffectStyle glassStyle API_AVAILABLE(ios(26.0));
 
 /// The text that is displayed in center of the button (Default is nil).
 /// This adds an internally controlled label view to the main content view.

--- a/TORoundedButton/TORoundedButton.h
+++ b/TORoundedButton/TORoundedButton.h
@@ -26,13 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class TORoundedButton;
 
-/// The types of static/dynamic visual styles that can be applied to the background.
-typedef NS_ENUM(NSInteger, TORoundedButtonBackgroundStyle) {
-    TORoundedButtonBackgroundStyleSolid,
-    TORoundedButtonBackgroundStyleBlur,
-    TORoundedButtonBackgroundStyleGlass
-};
-
 NS_SWIFT_NAME(RoundedButtonDelegate)
 @protocol TORoundedButtonDelegate <NSObject>
 
@@ -72,14 +65,11 @@ IB_DESIGNABLE @interface TORoundedButton : UIControl
 /// (Default value is 15 points inset from each edge).
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 
-/// The style, whether static or dynamic of the button's background view.
-@property (nonatomic, assign) TORoundedButtonBackgroundStyle backgroundStyle;
+/// Replaces the solid color background with a blur view. (Default is NO)
+@property (nonatomic, assign) BOOL isTranslucent;
 
-/// When `backgroundStyle` is set to `.blur`, the specific blur style to apply.
+/// When `isTranslucent` is `YES`, the amount of blur the background view has.
 @property (nonatomic, assign) UIBlurEffectStyle blurStyle;
-
-/// When `backgroundStyle` is set to `.blur`, the specific blur style to apply.
-@property (nonatomic, assign) UIGlassEffectStyle glassStyle API_AVAILABLE(ios(26.0));
 
 /// The text that is displayed in center of the button (Default is nil).
 /// This adds an internally controlled label view to the main content view.

--- a/TORoundedButton/TORoundedButton.h
+++ b/TORoundedButton/TORoundedButton.h
@@ -78,7 +78,7 @@ IB_DESIGNABLE @interface TORoundedButton : UIControl
 /// When `backgroundStyle` is set to `.blur`, the specific blur style to apply.
 @property (nonatomic, assign) UIBlurEffectStyle blurStyle;
 
-/// When `backgroundStyle` is set to `.blur`, the specific blur style to apply.
+/// When `backgroundStyle` is set to `.glass`, the specific glass style to apply.
 @property (nonatomic, assign) UIGlassEffectStyle glassStyle API_AVAILABLE(ios(26.0));
 
 /// The text that is displayed in center of the button (Default is nil).

--- a/TORoundedButton/TORoundedButton.h
+++ b/TORoundedButton/TORoundedButton.h
@@ -1,7 +1,7 @@
 //
 //  TORoundedButton.h
 //
-//  Copyright 2019-2023 Timothy Oliver. All rights reserved.
+//  Copyright 2019-2026 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to

--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -1,7 +1,7 @@
 //
 //  TORoundedButton.m
 //
-//  Copyright 2019-2023 Timothy Oliver. All rights reserved.
+//  Copyright 2019-2026 Timothy Oliver. All rights reserved.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to

--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -32,7 +32,7 @@ static inline BOOL TORoundedButtonFloatIsZero(CGFloat value) {
 }
 
 static inline BOOL TORoundedButtonFloatsMatch(CGFloat firstValue, CGFloat secondValue) {
-    return fabs(firstValue - secondValue) > FLT_EPSILON;
+    return fabs(firstValue - secondValue) < FLT_EPSILON;
 }
 
 static inline BOOL TORoundedButtonIsSolidBackground(TORoundedButtonBackgroundStyle backgroundStyle) {
@@ -134,13 +134,6 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
 #ifdef __IPHONE_13_0
     if (@available(iOS 13.0, *)) { _blurStyle = UIBlurEffectStyleSystemThinMaterial; }
 #endif
-
-    // Set the corner radius depending on system version
-    if (@available(iOS 26.0, *)) {
-        _cornerConfiguration = [UICornerConfiguration capsuleConfiguration];
-    } else {
-        _cornerRadius = (_cornerRadius > FLT_EPSILON) ?: 12.0f;
-    }
 
     // Set the tapped tint color if we've set to dynamically calculate it
     [self _updateTappedTintColorForTintColor];
@@ -469,12 +462,12 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
 
     const CGFloat scale = _isTapped ? _tappedButtonScale : 1.0f;
 
-    // Animate the alpha value of the label
+    // Animate the scale value of the label
     void (^animationBlock)(void) = ^{
         self->_containerView.transform = CGAffineTransformScale(CGAffineTransformIdentity,
                                                               scale,
                                                               scale);
-        };
+    };
 
     // If we're not animating, just call the blocks manually
     if (!animated) {

--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -122,6 +122,7 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
     // Set the corner radius depending on system version
 #ifdef __IPHONE_26_0
     if (@available(iOS 26.0, *)) {
+        _backgroundStyle = TORoundedButtonBackgroundStyleGlass;
         _cornerConfiguration = [UICornerConfiguration capsuleConfiguration];
     } else {
         _cornerRadius = (_cornerRadius > FLT_EPSILON) ?: 12.0f;
@@ -131,7 +132,7 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
 #endif
 
 #ifdef __IPHONE_13_0
-    if (@available(iOS 13.0, *)) { _blurStyle = UIBlurEffectStyleSystemThinMaterialDark; }
+    if (@available(iOS 13.0, *)) { _blurStyle = UIBlurEffectStyleSystemThinMaterial; }
 #endif
 
     // Set the corner radius depending on system version
@@ -649,7 +650,7 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
 
     UIGlassEffect *const glassEffect = [UIGlassEffect effectWithStyle:_glassStyle];
     glassEffect.tintColor = self.tintColor;
-    
+
     UIVisualEffectView *const effectView = (UIVisualEffectView *)_backgroundView;
     [effectView setEffect:glassEffect];
 }

--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -592,8 +592,18 @@ static inline BOOL TORoundedButtonIsDynamicBackground(TORoundedButtonBackgroundS
     _backgroundStyle = backgroundStyle;
     [_backgroundView removeFromSuperview];
     _backgroundView = [self _makeBackgroundViewWithStyle:_backgroundStyle];
-    [_containerView insertSubview:_backgroundView atIndex:0];
     _titleLabel.backgroundColor = [self _labelBackgroundColor];
+    const BOOL isGlass = backgroundStyle == TORoundedButtonBackgroundStyleGlass;
+    if (!isGlass) {
+        _containerView.hidden = NO;
+        [_containerView insertSubview:_backgroundView atIndex:0];
+        [_containerView addSubview:_contentView];
+    } else {
+        UIVisualEffectView *glassView = (UIVisualEffectView *)_backgroundView;
+        _containerView.hidden = YES;
+        [self insertSubview:glassView atIndex:0];
+        [glassView.contentView addSubview:_contentView];
+    }
     [self setNeedsLayout];
 }
 

--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -300,7 +300,7 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
 #ifdef __IPHONE_26_0
     if (@available(iOS 26.0, *)) {
         if (_backgroundStyle == TORoundedButtonBackgroundStyleGlass) {
-            UIGlassEffect *effect = [UIGlassEffect effectWithStyle:UIGlassEffectStyleRegular];
+            UIGlassEffect *effect = [UIGlassEffect effectWithStyle:_glassStyle];
             effect.tintColor = tintColor;
             [(UIVisualEffectView *)_backgroundView setEffect:effect];
         } else {
@@ -649,8 +649,7 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
 
     UIGlassEffect *const glassEffect = [UIGlassEffect effectWithStyle:_glassStyle];
     glassEffect.tintColor = self.tintColor;
-    glassEffect.interactive = YES;
-
+    
     UIVisualEffectView *const effectView = (UIVisualEffectView *)_backgroundView;
     [effectView setEffect:glassEffect];
 }

--- a/TORoundedButtonExample/ViewController.m
+++ b/TORoundedButtonExample/ViewController.m
@@ -20,8 +20,6 @@
     // Hide the tapped label
     self.tappedLabel.alpha = 0.0f;
 
-    self.button.backgroundStyle = TORoundedButtonBackgroundStyleGlass;
-
     __weak typeof(self) weakSelf = self;
     self.button.tappedHandler = ^{
         [weakSelf playFadeAnimationOnView:weakSelf.tappedLabel];

--- a/TORoundedButtonExample/ViewController.m
+++ b/TORoundedButtonExample/ViewController.m
@@ -20,6 +20,8 @@
     // Hide the tapped label
     self.tappedLabel.alpha = 0.0f;
 
+    self.button.backgroundStyle = TORoundedButtonBackgroundStyleGlass;
+
     __weak typeof(self) weakSelf = self;
     self.button.tappedHandler = ^{
         [weakSelf playFadeAnimationOnView:weakSelf.tappedLabel];

--- a/TORoundedButtonExampleTests/TORoundedButtonExampleTests.m
+++ b/TORoundedButtonExampleTests/TORoundedButtonExampleTests.m
@@ -20,7 +20,6 @@
     TORoundedButton *button = [[TORoundedButton alloc] initWithText:@"Test"];
     XCTAssertNotNil(button);
     XCTAssertEqual(button.text, @"Test");
-    XCTAssertEqual(button.cornerRadius, 12.0f);
     XCTAssertEqual(button.textColor, [UIColor whiteColor]);
     XCTAssertEqual(button.tappedTextAlpha, 1.0f);
     XCTAssertEqual(button.tappedTintColorBrightnessOffset, -0.15f);


### PR DESCRIPTION
Adds `TORoundedButtonBackgroundStyleGlass` as a new background style that is the default on iOS 26. It provides the specular tinted color effect, making the button look the same as the system buttons.