### PR TITLE
Refine the tapped color value

### DIFF
--- a/TORoundedButton/TORoundedButton.h
+++ b/TORoundedButton/TORoundedButton.h
@@ -116,7 +116,7 @@ IB_DESIGNABLE @interface TORoundedButton : UIControl
 @property (nonatomic, assign) IBInspectable CGFloat tappedTextAlpha;
 
 /// Taking the default button background color apply a brightness offset for the tapped color 
-/// (Default is -0.1f. Set 0.0 for off).
+/// (Default is 0.25f. Set 0.0 for off).
 @property (nonatomic, assign) IBInspectable CGFloat tappedTintColorBrightnessOffset;
 
 /// If desired, explicity set the background color of the button when tapped (Default is nil).

--- a/TORoundedButton/TORoundedButton.h
+++ b/TORoundedButton/TORoundedButton.h
@@ -125,8 +125,11 @@ IB_DESIGNABLE @interface TORoundedButton : UIControl
 /// When tapped, the scale by which the button shrinks during the animation (Default is 0.97f).
 @property (nonatomic, assign) IBInspectable CGFloat tappedButtonScale;
 
-/// The duration of the tapping cross-fade animation (Default is 0.4f).
-@property (nonatomic, assign) CGFloat tapAnimationDuration;
+/// The duration of the tap-down animation (Default is 0.1f).
+@property (nonatomic, assign) CGFloat tapDownAnimationDuration;
+
+/// The duration of the tap-up animation (Default is 0.4f).
+@property (nonatomic, assign) CGFloat tapUpAnimationDuration;
 
 /// A callback handler triggered each time the button is tapped.
 @property (nonatomic, copy) void (^tappedHandler)(void);

--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -116,7 +116,8 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
 - (void)_roundedButtonCommonInit TOROUNDEDBUTTON_OBJC_DIRECT {
     // Default properties (Make sure they're not overriding IB)
     _tappedTextAlpha = (_tappedTextAlpha > FLT_EPSILON) ?: 1.0f;
-    _tapAnimationDuration = (_tapAnimationDuration > FLT_EPSILON) ?: 0.4f;
+    _tapDownAnimationDuration = (_tapDownAnimationDuration > FLT_EPSILON) ?: 0.1f;
+    _tapUpAnimationDuration = (_tapUpAnimationDuration > FLT_EPSILON) ?: 0.4f;
     _tappedButtonScale = (_tappedButtonScale > FLT_EPSILON) ?: 0.97f;
     _tappedTintColorBrightnessOffset = !TORoundedButtonFloatIsZero(_tappedTintColorBrightnessOffset) ?: 0.25f;
     _contentInset = (UIEdgeInsets){15.0, 15.0, 15.0, 15.0};
@@ -385,7 +386,7 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
 
 - (void)_performTapAnimation:(void (^)(void))animations
                   completion:(void (^_Nullable)(BOOL finished))completion TOROUNDEDBUTTON_OBJC_DIRECT {
-    [UIView animateWithDuration:_tapAnimationDuration
+    [UIView animateWithDuration:_isTapped ? _tapDownAnimationDuration : _tapUpAnimationDuration
                           delay:0.0f
          usingSpringWithDamping:1.0f
           initialSpringVelocity:0.5f

--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -118,7 +118,7 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
     _tappedTextAlpha = (_tappedTextAlpha > FLT_EPSILON) ?: 1.0f;
     _tapAnimationDuration = (_tapAnimationDuration > FLT_EPSILON) ?: 0.4f;
     _tappedButtonScale = (_tappedButtonScale > FLT_EPSILON) ?: 0.97f;
-    _tappedTintColorBrightnessOffset = !TORoundedButtonFloatIsZero(_tappedTintColorBrightnessOffset) ?: -0.15f;
+    _tappedTintColorBrightnessOffset = !TORoundedButtonFloatIsZero(_tappedTintColorBrightnessOffset) ?: 0.25f;
     _contentInset = (UIEdgeInsets){15.0, 15.0, 15.0, 15.0};
     _blurStyle = UIBlurEffectStyleDark;
     _impactStyle = TORoundedButtonImpactStyleMedium;
@@ -669,13 +669,65 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
 }
 
 - (UIColor *)_brightnessAdjustedColorWithColor:(UIColor *)color amount:(CGFloat)amount TOROUNDEDBUTTON_OBJC_DIRECT {
-    if (!color) { return nil; }
+    // Clamp
+    amount = fmaxf(0.0, fminf(amount, 1.0));
 
-    CGFloat h, s, b, a;
-    if (![color getHue:&h saturation:&s brightness:&b alpha:&a]) { return nil; }
-    b += amount;
-    b = MAX(b, 0.0f); b = MIN(b, 1.0f);
-    return [UIColor colorWithHue:h saturation:s brightness:b alpha:a];
+    CGFloat h = 0, s = 0, b = 0, a = 0;
+    if (![color getHue:&h saturation:&s brightness:&b alpha:&a]) {
+        return color;
+    }
+
+    // Zones:
+    //  - RED   ≈ 0.0 / 1.0
+    //  - GREEN ≈ 0.33
+    //  - BLUE  ≈ 0.66
+    BOOL isRed   = (h < 0.05f || h > 0.95f);
+    BOOL isGreen = (h > 0.25f && h < 0.45f);
+    BOOL isBlue  = (h > 0.55f && h < 0.75f);
+
+    CGFloat hueShift      = 0.0f;
+    CGFloat satBoost      = 0.0f;
+    CGFloat brightnessAdd = 0.0f;
+
+    if (isRed) {
+        // systemRed → nudge toward orange/yellow, slightly brighter, modest sat
+        hueShift      =  0.08f * amount;  // towards yellow
+        satBoost      =  0.10f * amount;
+        brightnessAdd =  0.18f * amount;
+    }
+    else if (isGreen) {
+        // systemGreen → nudge toward yellow-green, clearly brighter + more vivid
+        hueShift      = -0.08f * amount;  // toward yellow-green
+        satBoost      =  0.25f * amount;  // push harder here
+        brightnessAdd =  0.22f * amount;  // stronger lift so it’s clearly changed
+    }
+    else if (isBlue) {
+        // systemBlue → nudge toward cyan, bright + vivid
+        hueShift      = -0.06f * amount;  // toward cyan
+        satBoost      =  0.18f * amount;
+        brightnessAdd =  0.18f * amount;
+    }
+    else {
+        // Everything else: mild generic brighten + hue wobble
+        hueShift      = -0.03f * amount;
+        satBoost      =  0.15f * amount;
+        brightnessAdd =  0.18f * amount;
+    }
+
+    // Apply hue shift with wrapping
+    CGFloat newH = h + hueShift;
+    if (newH < 0.0f) newH += 1.0f;
+    if (newH > 1.0f) newH -= 1.0f;
+
+    // Brighten: constant bump + small relative lift if not already maxed
+    CGFloat newB = b + brightnessAdd + (1.0f - b) * 0.2f * amount;
+    newB = fminf(newB, 1.0f);
+
+    // Saturation boost, clamped
+    CGFloat newS = s + satBoost;
+    newS = fminf(newS, 1.0f);
+
+    return [UIColor colorWithHue:newH saturation:newS brightness:newB alpha:a];
 }
 
 @end

--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -258,7 +258,11 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
     [super traitCollectionDidChange:previousTraitCollection];
     [self setNeedsLayout];
-    [self _updateTappedTintColorForTintColor];
+    if (@available(iOS 13.0, *)) {
+        if ([previousTraitCollection hasDifferentColorAppearanceComparedToTraitCollection:self.traitCollection]) {
+            [self _updateTappedTintColorForTintColor];
+        }
+    }
 }
 
 #pragma mark - View Layout -
@@ -657,7 +661,6 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
     if (@available(iOS 13.0, *)) {
         tintColor = [tintColor resolvedColorWithTraitCollection:self.traitCollection];
     }
-
     _tappedTintColor = [self _brightnessAdjustedColorWithColor:tintColor
                                                         amount:_tappedTintColorBrightnessOffset];
 }

--- a/TORoundedButton/TORoundedButton.m
+++ b/TORoundedButton/TORoundedButton.m
@@ -670,18 +670,16 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
 }
 
 - (UIColor *)_brightnessAdjustedColorWithColor:(UIColor *)color amount:(CGFloat)amount TOROUNDEDBUTTON_OBJC_DIRECT {
-    // Clamp
+    // Clamp provided value just in case
     amount = fmaxf(0.0, fminf(amount, 1.0));
 
     CGFloat h = 0, s = 0, b = 0, a = 0;
-    if (![color getHue:&h saturation:&s brightness:&b alpha:&a]) {
-        return color;
-    }
+    if (![color getHue:&h saturation:&s brightness:&b alpha:&a]) { return color; }
 
     // Zones:
-    //  - RED   ≈ 0.0 / 1.0
-    //  - GREEN ≈ 0.33
-    //  - BLUE  ≈ 0.66
+    //  - RED   - 0.0 / 1.0
+    //  - GREEN - 0.33
+    //  - BLUE  - 0.66
     BOOL isRed   = (h < 0.05f || h > 0.95f);
     BOOL isGreen = (h > 0.25f && h < 0.45f);
     BOOL isBlue  = (h > 0.55f && h < 0.75f);
@@ -691,19 +689,19 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
     CGFloat brightnessAdd = 0.0f;
 
     if (isRed) {
-        // systemRed → nudge toward orange/yellow, slightly brighter, modest sat
+        // systemRed - nudge toward orange/yellow, slightly brighter, modest sat
         hueShift      =  0.08f * amount;  // towards yellow
         satBoost      =  0.10f * amount;
         brightnessAdd =  0.18f * amount;
     }
     else if (isGreen) {
-        // systemGreen → nudge toward yellow-green, clearly brighter + more vivid
+        // systemGreen - nudge toward yellow-green, clearly brighter + more vivid
         hueShift      = -0.08f * amount;  // toward yellow-green
         satBoost      =  0.25f * amount;  // push harder here
         brightnessAdd =  0.22f * amount;  // stronger lift so it’s clearly changed
     }
     else if (isBlue) {
-        // systemBlue → nudge toward cyan, bright + vivid
+        // systemBlue - nudge toward cyan, bright + vivid
         hueShift      = -0.06f * amount;  // toward cyan
         satBoost      =  0.18f * amount;
         brightnessAdd =  0.18f * amount;
@@ -717,8 +715,8 @@ static inline BOOL TORoundedButtonIsTintableBackground(TORoundedButtonBackground
 
     // Apply hue shift with wrapping
     CGFloat newH = h + hueShift;
-    if (newH < 0.0f) newH += 1.0f;
-    if (newH > 1.0f) newH -= 1.0f;
+    if (newH < 0.0f) { newH += 1.0f; }
+    if (newH > 1.0f) { newH -= 1.0f; }
 
     // Brighten: constant bump + small relative lift if not already maxed
     CGFloat newB = b + brightnessAdd + (1.0f - b) * 0.2f * amount;

--- a/TORoundedButtonExampleTests/TORoundedButtonExampleTests.m
+++ b/TORoundedButtonExampleTests/TORoundedButtonExampleTests.m
@@ -22,7 +22,7 @@
     XCTAssertEqual(button.text, @"Test");
     XCTAssertEqual(button.textColor, [UIColor whiteColor]);
     XCTAssertEqual(button.tappedTextAlpha, 1.0f);
-    XCTAssertEqual(button.tappedTintColorBrightnessOffset, -0.15f);
+    XCTAssertEqual(button.tappedTintColorBrightnessOffset, 0.25f);
     XCTAssertEqual(button.tappedButtonScale, 0.97f);
 
 #ifdef __IPHONE_26_0


### PR DESCRIPTION
Fixes the default value of the calculated 'tapped' color to align more with Liquid Glass.

I used ChatGPT to come up with the algorithm. Color theory is not linear, and a lot of Apple's semantic colors already have max saturation and brightness so the only way to get a perceptible change is to change the hue. I'll continue to tweak this as I play with more colors with it.